### PR TITLE
Add Scala 3 RC3 to the build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
           - 3.0.0-M3
           - 3.0.0-RC1
           - 3.0.0-RC2
+          - 3.0.0-RC3
         java: [graalvm-ce-java11@20.3.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -87,7 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.0.0-RC1]
+        scala: [3.0.0-RC3]
         java: [graalvm-ce-java11@20.3.0]
     runs-on: ${{ matrix.os }}
     steps:
@@ -229,6 +230,16 @@ jobs:
           name: target-${{ matrix.os }}-3.0.0-RC2-${{ matrix.java }}
 
       - name: Inflate target directories (3.0.0-RC2)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3.0.0-RC3)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-3.0.0-RC3-${{ matrix.java }}
+
+      - name: Inflate target directories (3.0.0-RC3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The plugin is currently published for the following Scala versions:
 
 - 2.12.10, 2.12.11, 2.12.12, 2.12.13
 - 2.13.1, 2.13.2, 2.13.3, 2.13.4, 2.13.5
-- 3.0.0-M3, 3.0.0-RC1, 3.0.0-RC2
+- 3.0.0-M3, 3.0.0-RC1, 3.0.0-RC2, 3.0.0-RC3
 
 ## What does the plugin actually do?
 

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ def scalatestVersion(scalaVersion: String) =
   scalaVersion match {
     case "3.0.0-M3"  => "3.2.3"
     case "3.0.0-RC1" => "3.2.5"
-    case "3.0.0-RC2" => "2.3.7"
+    case "3.0.0-RC2" => "3.2.7"
     case _           => "3.2.8"
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ inThisBuild(
 
 val GraalVM11 = "graalvm-ce-java11@20.3.0"
 
-ThisBuild / scalaVersion := "3.0.0-RC1"
+ThisBuild / scalaVersion := "3.0.0-RC3"
 ThisBuild / crossScalaVersions := Seq(
   "2.12.10",
   "2.12.11",
@@ -39,7 +39,8 @@ ThisBuild / crossScalaVersions := Seq(
   //
   "3.0.0-M3",
   "3.0.0-RC1",
-  "3.0.0-RC2"
+  "3.0.0-RC2",
+  "3.0.0-RC3"
 )
 
 ThisBuild / githubWorkflowJavaVersions := Seq(GraalVM11)
@@ -71,7 +72,8 @@ def scalatestVersion(scalaVersion: String) =
   scalaVersion match {
     case "3.0.0-M3"  => "3.2.3"
     case "3.0.0-RC1" => "3.2.5"
-    case _           => "3.2.7"
+    case "3.0.0-RC2" => "2.3.7"
+    case _           => "3.2.8"
   }
 
 val plugin = project.settings(


### PR DESCRIPTION
Closes #28

That's 13 versions now. After 3.0.0 final is released, I think we'll drop all the RCs except the latest, and possibly start removing older versions of 2.12 / 2.13.